### PR TITLE
feat: confirm report copy

### DIFF
--- a/src/nyb/assets/gui/encrypt.html
+++ b/src/nyb/assets/gui/encrypt.html
@@ -243,7 +243,8 @@
         const tds = tr.querySelectorAll('td');
         lines.push([tds[0].innerText, tds[1].innerText.trim(), tds[2].innerText, tds[3].innerText].join(';'));
       });
-      navigator.clipboard.writeText(lines.join('\n'));
+      navigator.clipboard.writeText(lines.join('\n'))
+        .then(() => alert('Raport został skopiowany do schowka.'));
     });
   </script>
 </body>

--- a/src/nyb/gui/progress_view.py
+++ b/src/nyb/gui/progress_view.py
@@ -100,3 +100,4 @@ class ProgressView(QWidget):
             row = [self.table.item(r, c).text() if self.table.item(r, c) else "" for c in range(4)]
             rows.append("\t".join(row))
         QGuiApplication.clipboard().setText("\n".join(rows))
+        QMessageBox.information(self, "Raport", "Raport został skopiowany do schowka.")


### PR DESCRIPTION
## Summary
- show a popup after copying report in progress view
- alert user when report is copied on encrypt page

## Testing
- `pytest -q` *(fails: AssertionError in tests/test_walker_exclusions.py::test_walker_basic)*

------
https://chatgpt.com/codex/tasks/task_e_689d596799448329899014fd5cdd8a15